### PR TITLE
Introduced pylint and flutter analyze precommit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ python manage.py runserver
 flutter run -t lib/main_dev.dart
 ```
 
+7. Setup pre commit hook
+```
+./setup_hooks.sh
+```
+
 **Codebase Infrastructure**
 
 The backend code mainly resides in the `api` folder and the frontend code resides in the `app` folder.

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+pylint $(git ls-files 'api/**/*.py')
+
+if [ $? -ne 0 ]; then
+    echo "Python lint tests are failing"
+    exit 1
+fi
+
+cd app
+flutter analyze
+
+if [ $? -ne 0 ]; then
+    echo "Flutter analyze is failing"
+    exit 1
+fi

--- a/setup_hooks.sh
+++ b/setup_hooks.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cp pre-commit.sh .git/hooks/pre-commit
+
+chmod +x .git/hooks/pre-commit


### PR DESCRIPTION
This PR introduces `pylint` and `flutter analyze` pre-commit hook.

This hook will disallow python and flutter code having linting errors from being committed locally.

The hook can be bypassed with `--no-verify` flag.

![image](https://user-images.githubusercontent.com/106883815/186435366-d9ed0da7-587c-4eea-bedc-cb4cd893a965.png)


