### PR TITLE
Create mess menu api for manager side and also fix warnings

### DIFF
--- a/api/mess/serializers.py
+++ b/api/mess/serializers.py
@@ -2,12 +2,14 @@ from mess.models import MenuItem
 from rest_framework import serializers
 
 class MenuItemSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
     name = serializers.CharField(max_length=30)
 
     class Meta:
         model = MenuItem
 
 class MenuSlotSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
     name = serializers.CharField(max_length=15)
     start_time = serializers.TimeField()
     end_time = serializers.TimeField()
@@ -50,5 +52,6 @@ class MessTenderSer(serializers.Serializer):
     created_at = serializers.DateTimeField()
 
 class MessMenuSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
     slot = MenuSlotSerializer()
     items = MenuItemSerializer(many = True)

--- a/api/mess/urls.py
+++ b/api/mess/urls.py
@@ -42,4 +42,6 @@ urlpatterns = [
          views.FeedbackActionView.as_view(), name="feedback action"),
     path('tender/archive/<int:pk>/', views.MessTenderArchivedView.as_view(),
          name="tender action"),
+     path('menu/timing', views.MenuTimingView.as_view(), name="Menu timing"),
+     path('menu/item_update', views.MenuItemUpdateView.as_view(), name='Menu item update')
 ]

--- a/api/mess/views.py
+++ b/api/mess/views.py
@@ -210,3 +210,48 @@ class MessTenderInstanceView(APIView):
         data = self.model.objects.filter(id=tender_id).first()
         serialized_json = MessTenderSer(data)
         return Response(data=serialized_json.data)
+
+class MenuTimingView(APIView):
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        start_time = request.POST.get('start_time')
+        end_time = request.POST.get('end_time')
+        slot_id = request.POST.get('slot_id')
+
+        slot = MenuSlot.objects.filter(id = slot_id).first()
+
+        slot.start_time = start_time
+        slot.end_time = end_time
+        slot.save()
+
+        return Response(status = 200, data={
+            'msg': 'Successfully updated menu timings'
+        })
+
+class MenuItemUpdateView(APIView):
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        menu_id = request.POST.get('menu_id')
+        menu_item_id = request.POST.get('menu_item_id')
+        action = request.POST.get('action')
+
+        menu = MessMenu.objects.filter(id = menu_id).first()
+        menu_item = MenuItem.objects.filter(id = menu_item_id).first()
+
+        if action == 'remove':
+            menu.items.remove(menu_item)
+        elif action == 'add':
+            menu.items.add(menu_item)
+        else:
+            return Response(status = 400, data={
+                'msg': 'action field is malformed'
+            })
+
+
+        return Response(status = 200, data={
+            'msg': 'Successfully updated mess menu item'
+        })

--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/app/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip


### PR DESCRIPTION
Created mess menu api:

1. /mess/menu/timing : To update the timing of a menu slot. Provide mess_slot_id, start_time and end_time in POST request.
2. /menu/item_update: Add or remove items of a particular mess menu. Provide menu_id, menu_item_id and action (add/remove) with POST request.