### PR TITLE
Make general feed api backward compatible with v1.1.2

### DIFF
--- a/api/feed/serializers.py
+++ b/api/feed/serializers.py
@@ -19,3 +19,16 @@ class PostSerializer(serializers.Serializer):
 
     def __str__(self):
         return self.body
+
+
+class PostSerializerCompatibleWith112(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    user = UserSerializer()
+    body = serializers.CharField(max_length=30)
+    attachments = DocumentSerializer(many = True)
+    created_at = serializers.DateTimeField()
+    updated_at = serializers.DateTimeField()
+    student_profile = StudentSerializer()
+
+    def __str__(self):
+        return self.body

--- a/api/institute_app/settings.py
+++ b/api/institute_app/settings.py
@@ -64,7 +64,8 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'authentication.backends.UserAuthenticationBackend',
         'authentication.backends.StaffAuthenticationBackend'
-    )
+    ),
+    'DEFAULT_VERSIONING_CLASS': 'institute_app.versioning.AcceptHeaderVersioningWithParameters'
 }
 
 MIDDLEWARE = [

--- a/api/institute_app/versioning.py
+++ b/api/institute_app/versioning.py
@@ -1,0 +1,5 @@
+from rest_framework.versioning import AcceptHeaderVersioning
+
+class AcceptHeaderVersioningWithParameters(AcceptHeaderVersioning):
+  default_version = '1.1.2'
+  allowed_versions = ['1.1.3', '1.1.2']

--- a/app/lib/screens/dashboard/general_feed/general_feed.dart
+++ b/app/lib/screens/dashboard/general_feed/general_feed.dart
@@ -65,6 +65,8 @@ class _GeneralFeedState extends State<GeneralFeed> {
           baseUrl + '/feed/feed/',
         ),
         headers: <String, String>{
+          // Accept header should be set to access the correct api.
+          'Accept': 'application/json; version=1.1.3',
           'Content-Type': 'application/json; charset=UTF-8',
           'Authorization': 'idToken ' + idToken!
         });


### PR DESCRIPTION
Make general feed API backward compatible with v1.1.2

General feed on older clients will not break as a compatible serializer is used.